### PR TITLE
Adding support for command line tool in poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ moto = "^2.2.9"
 pytest-asyncio = "^0.16.0"
 twine = "^4.0.1"
 
+[tool.poetry.scripts]
+rdfx = "rdfx.rdfx_cli:main"
+
 [tool.poetry.extras]
 app = ["streamlit", "python-dotenv"]
 

--- a/rdfx/rdfx_cli.py
+++ b/rdfx/rdfx_cli.py
@@ -152,7 +152,7 @@ def clean_ttl(input_file_path:Path):
         ps.write(g=g, filename=input_file_path.stem)
 
 
-if __name__ == "__main__":
+def main():
     if "-h" not in sys.argv and len(sys.argv) < 3:
         print(
             "ERROR: You must supply at a minimum the method (convert or merge), a file or files, and a target format"
@@ -215,3 +215,5 @@ if __name__ == "__main__":
         for file in files_list:
             clean_ttl(file)
 
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
It is useful to have the rdfx command installed in the python bin executable path instead of using python to execute the command line tool. This pull request adds the poetry configuration to install the rdfx script with an entry point of rdfx.rdfx_cli:main when installed from pypi. The rdfx.py file needed to be slightly modified to define the main() function and to have the script entry point __main__ call main() to retain previous functionality.